### PR TITLE
Scripted PR to add .dockerignore file if missing, or update an existing .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,11 @@
 .github/
 .idea/
+**/.git
+**/.gitignore
+**/.circleci/
+**/.gitlab-ci.*
+**/.env*
+**/docker-compose*
+Dockerfile*
+.dockerignore
+Jenkinsfile

--- a/vendor/github.com/pelletier/go-toml/.dockerignore
+++ b/vendor/github.com/pelletier/go-toml/.dockerignore
@@ -1,2 +1,11 @@
 cmd/tomll/tomll
 cmd/tomljson/tomljson
+**/.git
+**/.gitignore
+**/.circleci/
+**/.gitlab-ci.*
+**/.env*
+**/docker-compose*
+Dockerfile*
+.dockerignore
+Jenkinsfile

--- a/vendor/golang.org/x/net/http2/.dockerignore
+++ b/vendor/golang.org/x/net/http2/.dockerignore
@@ -1,0 +1,9 @@
+**/.git
+**/.gitignore
+**/.circleci/
+**/.gitlab-ci.*
+**/.env*
+**/docker-compose*
+Dockerfile*
+.dockerignore
+Jenkinsfile


### PR DESCRIPTION

SUMMARY
Add .dockerignore file if missing, or update existing .dockerignore
A scripted PR created by DevOps team
